### PR TITLE
Fixed input height for IE. Removed IE native clear control on inputs

### DIFF
--- a/style/input/input-m.css
+++ b/style/input/input-m.css
@@ -16,6 +16,7 @@
 
   font-size: size-m;
   line-height: line-m;
+  height: : line-m;
 }
 
 .clear

--- a/style/input/input-m.css
+++ b/style/input/input-m.css
@@ -16,7 +16,7 @@
 
   font-size: size-m;
   line-height: line-m;
-  height: : line-m;
+  height: line-m;
 }
 
 .clear

--- a/style/input/input-s.css
+++ b/style/input/input-s.css
@@ -16,7 +16,7 @@
 
   font-size: size-s;
   line-height: line-s;
-  height: : line-s;
+  height: line-s;
 }
 
 .clear

--- a/style/input/input-s.css
+++ b/style/input/input-s.css
@@ -16,6 +16,7 @@
 
   font-size: size-s;
   line-height: line-s;
+  height: : line-s;
 }
 
 .clear

--- a/style/input/input-xs.css
+++ b/style/input/input-xs.css
@@ -16,6 +16,7 @@
 
   font-size: size-xs;
   line-height: line-xs;
+  height: : line-xs;
 }
 
 .clear

--- a/style/input/input-xs.css
+++ b/style/input/input-xs.css
@@ -16,7 +16,7 @@
 
   font-size: size-xs;
   line-height: line-xs;
-  height: : line-xs;
+  height: line-xs;
 }
 
 .clear

--- a/style/input/input.css
+++ b/style/input/input.css
@@ -27,6 +27,11 @@
   -webkit-tap-highlight-color: transparent;
 }
 
+.control::-ms-clear
+{
+  display: none;
+}
+
 .control::-webkit-input-placeholder,
 .control:-moz-placeholder,
 .control::-moz-placeholder,


### PR DESCRIPTION
Cause of: http://joshnh.com/weblog/line-height-doesnt-work-as-expected-on-inputs/

And: http://stackoverflow.com/questions/14007655/remove-ie10s-clear-field-x-button-on-certain-inputs