### PR TITLE
Add 1px margin to select menu item to prevent border overlay

### DIFF
--- a/style/select/select.css
+++ b/style/select/select.css
@@ -86,6 +86,8 @@
   display: block;
   overflow-x: hidden;
 
+  margin: 0px 1px;
+
   cursor: pointer;
   white-space: nowrap;
   text-overflow: ellipsis;


### PR DESCRIPTION
It seems to me that the hovered item tries to get out of borders.

Before: 
<img width="228" alt="2017-10-18 21 56 25" src="https://user-images.githubusercontent.com/25570775/31738585-d5eb6808-b453-11e7-8c4b-1ddfe922702b.png">

After:
<img width="227" alt="2017-10-18 21 55 51" src="https://user-images.githubusercontent.com/25570775/31738545-b337e336-b453-11e7-9841-f6190dab3f43.png">
